### PR TITLE
Add fix for CVE-2024-21534 and CVE-2025-1302

### DIFF
--- a/src/jsonpath-node.js
+++ b/src/jsonpath-node.js
@@ -1,10 +1,9 @@
 import vm from 'vm';
 import {JSONPath} from './jsonpath.js';
+import {SafeScript} from './jsonpath-browser.js';
 
 JSONPath.prototype.vm = vm;
-JSONPath.prototype.safeVm = vm;
-
-const SafeScript = vm.Script;
+JSONPath.prototype.safeVm = {Script: SafeScript};
 
 export {
     JSONPath,

--- a/src/jsonpath.js
+++ b/src/jsonpath.js
@@ -651,6 +651,10 @@ JSONPath.prototype._eval = function (
         if (containsPath) {
             script = script.replace(/@path/gu, '_$_path');
         }
+        const forbiddenPattern = /\b(?:constructor|Function|process|require|global|this|eval\s*\(|vm\s*\.\s*runInNewContext|spawn|execSync|bind|apply)\b/u;
+        if (forbiddenPattern.test(script)) {
+            throw new Error('Unsafe expression rejected by JSONPath');
+        }
         if (
             this.currEval === 'safe' ||
             this.currEval === true ||

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -1,5 +1,5 @@
-import { promisify } from "util";
-import { exec as _exec } from "child_process";
+import {promisify} from "util";
+import {exec as _exec} from "child_process";
 import path from "path";
 
 const exec = promisify(_exec);
@@ -19,6 +19,5 @@ describe("JSONPath - cli", () => {
         expect(out.stderr).to.include(`usage: ${binPath} <file> <path>`);
         expect(out.stderr).to.include("ENOENT: no such file or directory");
         expect(out.stderr).to.include("open 'wrong-file.json'");
-        ;
     });
 });

--- a/test/test.cvefix.js
+++ b/test/test.cvefix.js
@@ -1,0 +1,121 @@
+import {checkBuiltInVMAndNodeVM} from '../test-helpers/checkVM.js';
+
+checkBuiltInVMAndNodeVM(function (vmType, setBuiltInState) {
+    describe(`JSONPath - Potentially malicious path expression tests (${vmType})`, function () {
+        before(setBuiltInState);
+
+        const json = {
+            "name": "root",
+            "children": [
+                {"name": "child1", "children": [{"name": "child1_1"}, {"name": "child1_2"}]},
+                {"name": "child2", "children": [{"name": "child2_1"}]},
+                {"name": "child3", "children": [{"name": "child3_1"}, {"name": "child3_2"}]}
+            ]
+        };
+
+        const pathDoS = "$[?(con = constructor; dp = con.defineProperty; gopd = con.getOwnPropertyDescriptor; f = gopd(con, 'entries').value; alt = gopd(con.getPrototypeOf(f), 'apply'); dp(con.getPrototypeOf(_$_root.body), 'toString', alt);)]";
+
+        it('should throw when using "process" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$[?(@.foo === process)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "constructor" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$..[?(constructor)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "eval(" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$[?(@.data === eval(123))]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "Function" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$[?(@.test === Function)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "vm.runInNewContext" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$..[?(@.key === vm.runInNewContext)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "spawn" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$[?(@.action === spawn)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "bind" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$..[?(@.something === bind)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "apply" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$[?(@.testVal === apply)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using "execSync" literal in path', () => {
+            expect(() => {
+                jsonpath({
+                    json,
+                    path: '$..[?(@.cmdExec === execSync)]'
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+
+        it('should throw when using a complete DoS/SSRF script', () => {
+            expect(() => {
+                jsonpath({
+                    json: {
+                        referrer: {
+                            value: "http://authorized.com",
+                            writable: true
+                        },
+                        method: {
+                            value: "POST",
+                            writable: true
+                        },
+                        body: {
+                            value: "Hello, World!",
+                            writable: true
+                        }
+                    },
+                    path: pathDoS
+                });
+            }).to.throw(Error, /Unsafe expression rejected by JSONPath/u);
+        });
+    });
+});

--- a/test/test.errors.js
+++ b/test/test.errors.js
@@ -76,7 +76,7 @@ checkBuiltInVMAndNodeVM(function (vmType, setBuiltInState) {
                     wrap: false,
                     eval: 'safe'
                 });
-            }).to.throw(Error, 'jsonPath: Unexpected expression: this');
+            }).to.throw(Error, /Unsafe expression rejected/u);
         });
 
         it('Invalid assignment in safe mode script', () => {


### PR DESCRIPTION
The PR fixes the high-severity vulnerabilities (CVE-2024-21534 and CVE-2025-1302) . It introduces a fix by adding sanitization for user input to avoid Remote Code Execution (RCE)


### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2024-21534                                                                                  |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | All versions of the package jsonpath-plus are vulnerable to Remote Code Execution (RCE) due to improper input sanitization. |

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2025-1302                                                                                  |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | Versions of the package jsonpath-plus before 10.3.0 are vulnerable to Remote Code Execution (RCE) due to improper input sanitization. An attacker can execute aribitrary code on the system by exploiting the unsafe default usage of eval='safe' mode |




